### PR TITLE
Add script to download paley matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,14 +81,14 @@ jobs:
       run: |
           pip install pytest
           pip install -e .
-          python -m pytest --doctest-modules --ignore=tutorial --ignore=docs --ignore=spyrit/dev || exit -1
+          python -m pytest --doctest-modules --ignore=tutorial --ignore=docs --ignore=spyrit/dev --ignore=spyrit/hadamard_matrix || exit -1
     - name: Run the tests on Windows
       if: matrix.os == 'windows-latest'
       shell: cmd
       run: |
           pip install pytest
           pip install -e .
-          python -m pytest --doctest-modules --ignore=tutorial --ignore=docs --ignore=spyrit\dev || exit /b -1
+          python -m pytest --doctest-modules --ignore=tutorial --ignore=docs --ignore=spyrit\dev --ignore=spyrit\hadamard_matrix || exit /b -1
 
   test_wheel:
     runs-on: ${{ matrix.os }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__
 *.sh
 *.ipynb
 *.npy
+*.npz
 
 #folders
 data

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,5 +50,6 @@ dependencies = [
         "imageio",
         "astropy",
         "requests",
+        "tqdm",
 ]
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,5 +49,6 @@ dependencies = [
         "sympy",
         "imageio",
         "astropy",
+        "requests",
 ]
 requires-python = ">=3.9"

--- a/spyrit/hadamard_matrix/create_hadamard_matrix_with_sage.py
+++ b/spyrit/hadamard_matrix/create_hadamard_matrix_with_sage.py
@@ -1,0 +1,41 @@
+from sage.all import *
+from sage.combinat.matrices.hadamard_matrix import (
+    hadamard_matrix,
+    skew_hadamard_matrix,
+    is_hadamard_matrix,
+    is_skew_hadamard_matrix,
+)
+import numpy as np
+import glob
+
+# Get all Hadamard matrices of order 4*n for Sage
+# https://github.com/sagemath/sage/
+# run in conda env with:
+# sage create_hadamard_matrix_with_sage.py
+
+k = Integer(2000)
+for n in range(Integer(1), k + Integer(1)):
+    try:
+        H = hadamard_matrix(Integer(4) * n, check=False)
+
+        if is_hadamard_matrix(H):
+            print(n * 4)
+            a = np.array(H)
+            a[a == -1] = 0
+            a = a.astype(bool)
+
+            # find the files with that order
+            files = glob.glob("had." + str(n * 4) + "*.npz")
+            already_saved = False
+            for file in files:
+                b = np.load(file)
+                if a == b:
+                    already_saved = True
+                if already_saved:
+                    break
+
+            if not already_saved:
+                name = "had." + str(n * 4) + ".sage.npz"
+                np.savez_compressed(name, a)
+    except ValueError as e:
+        pass

--- a/spyrit/hadamard_matrix/download_hadamard_matrix.py
+++ b/spyrit/hadamard_matrix/download_hadamard_matrix.py
@@ -2,6 +2,7 @@ import numpy as np
 import requests
 import os
 import glob
+import importlib.util
 
 
 def download_from_girder():
@@ -54,6 +55,7 @@ def read_text_file_from_url(url):
     content = response.text
     return content
 
+
 def download_from_sloane():
     from selenium import webdriver
     from selenium.webdriver.common.by import By
@@ -70,7 +72,7 @@ def download_from_sloane():
     links = driver.find_elements(By.XPATH, "//a[contains(@href, 'had.')]")
 
     # Extract the URLs
-    hadamard_urls = set([link.get_attribute('href') for link in links])
+    hadamard_urls = set([link.get_attribute("href") for link in links])
 
     # Print the URLs
     for url in hadamard_urls:
@@ -81,7 +83,7 @@ def download_from_sloane():
         lines = file_content.splitlines()
 
         # Print the content of the file
-        if '+' in file_content or '0' in file_content or '-1' in file_content:
+        if "+" in file_content or "0" in file_content or "-1" in file_content:
             if len(lines) > 1:
                 size = len(lines[1])
             else:
@@ -92,9 +94,9 @@ def download_from_sloane():
                     line = line.replace("-1", "0")
                     tmp = []
                     for e in line:
-                        if e == '+' or e == '1':
+                        if e == "+" or e == "1":
                             tmp += [1]
-                        elif e == '-' or e == '0':
+                        elif e == "-" or e == "0":
                             tmp += [0]
                         elif e == " ":
                             pass
@@ -120,11 +122,11 @@ def download_from_sloane():
                 np.savez_compressed(name + ".npz", np_array)
         else:
             print("no ok for " + url)
-        #print(file_content)
+        # print(file_content)
 
     # Close the WebDriver
     driver.quit()
 
+
 if __name__ == "__main__":
     download_from_sloane()
-

--- a/spyrit/hadamard_matrix/download_hadamard_matrix.py
+++ b/spyrit/hadamard_matrix/download_hadamard_matrix.py
@@ -1,0 +1,68 @@
+import numpy as np
+import requests
+
+def read_text_file_from_url(url):
+    response = requests.get(url)
+    content = response.text
+    return content
+
+def download_from_sloane():
+    from selenium import webdriver
+    from selenium.webdriver.common.by import By
+    from selenium.webdriver.chrome.service import Service
+    from webdriver_manager.chrome import ChromeDriverManager
+
+    # Set up the WebDriver
+    driver = webdriver.Chrome(service=Service(ChromeDriverManager().install()))
+
+    # Open the website
+    driver.get("http://neilsloane.com/hadamard/")
+
+    # Find all links to Hadamard matrices
+    links = driver.find_elements(By.XPATH, "//a[contains(@href, 'had.')]")
+
+    # Extract the URLs
+    hadamard_urls = set([link.get_attribute('href') for link in links])
+
+    # Print the URLs
+    for url in hadamard_urls:
+        print(url)
+        # Read the text file from the URL
+        file_content = read_text_file_from_url(url)
+        # Split the content into lines
+        lines = file_content.splitlines()
+
+        # Print the content of the file
+        if '+' in file_content or '0' in file_content or '-1' in file_content:
+            if len(lines) > 1:
+                size = len(lines[1])
+            else:
+                size = len(lines[0])
+            array = []
+            for line in lines:
+                if len(line) == size:
+                    line = line.replace("-1", "0")
+                    tmp = []
+                    for e in line:
+                        if e == '+' or e == '1':
+                            tmp += [1]
+                        elif e == '-' or e == '0':
+                            tmp += [0]
+                        elif e == " ":
+                            pass
+                        else:
+                            print("Error during reading of " + url)
+                    array += [tmp]
+            np_array = np.array(array, dtype=bool)
+            name = url.split('/')[-1][:-4]
+            np.savez_compressed(name + '.npz', np_array)
+        else:
+            print("no ok for " + url)
+        #print(file_content)
+
+    # Close the WebDriver
+    driver.quit()
+
+if __name__ == "__main__":
+    download_from_sloane()
+

--- a/spyrit/hadamard_matrix/download_hadamard_matrix.py
+++ b/spyrit/hadamard_matrix/download_hadamard_matrix.py
@@ -11,7 +11,9 @@ def download_from_girder():
     """
 
     hadamard_matrix_path = os.path.dirname(__file__)
-    if os.path.isfile(os.path.join(hadamard_matrix_path, "had.20.1.npz")):
+    if os.path.isfile(
+        os.path.join(hadamard_matrix_path, "had.236.sage.cooper-wallis.npz")
+    ):
         return
     print("Downloading Hadamard matrices from Girder repository...")
     print(

--- a/spyrit/hadamard_matrix/download_hadamard_matrix.py
+++ b/spyrit/hadamard_matrix/download_hadamard_matrix.py
@@ -3,6 +3,7 @@ import requests
 import os
 import glob
 import importlib.util
+import tqdm
 
 
 def download_from_girder():
@@ -15,7 +16,7 @@ def download_from_girder():
         os.path.join(hadamard_matrix_path, "had.236.sage.cooper-wallis.npz")
     ):
         return
-    print("Downloading Hadamard matrices from Girder repository...")
+    print("Downloading Hadamard matrices (>2300) from Girder repository...")
     print(
         "The matrices were downloaded from http://neilsloane.com/hadamard/ Sloane et al."
     )
@@ -29,6 +30,7 @@ def download_from_girder():
     folder_id = "6800c6891240141f6aa53845"
     limit = 50  # Number of items to retrieve per request
     offset = 0  # Starting point
+    pbar = tqdm.tqdm(total=0)
 
     while True:
         items = gc.get(
@@ -43,13 +45,17 @@ def download_from_girder():
         )
         if not items:
             break
+        pbar.total += len(items)
+        pbar.refresh()
         for item in items:
             files = gc.get(f'item/{item["_id"]}/files')
             for file in files:
+                pbar.update(1)
                 gc.downloadFile(
                     file["_id"], os.path.join(hadamard_matrix_path, file["name"])
                 )
         offset += limit
+    pbar.close()
 
 
 def read_text_file_from_url(url):

--- a/spyrit/misc/walsh_hadamard.py
+++ b/spyrit/misc/walsh_hadamard.py
@@ -40,6 +40,7 @@ import math
 import torch
 import numpy as np
 import re
+import glob
 
 import spyrit.core.torch as spytorch
 from sympy.combinatorics.graycode import GrayCode
@@ -1413,7 +1414,7 @@ def check_downloaded_hadamard_matrix():
     return folder
 
 
-def load_matrix(order, name=""):
+def load_matrix(order, name="sage"):
     """Load the Walsh-Hadamard matrix from a file
 
     Args:
@@ -1444,9 +1445,9 @@ def load_matrix(order, name=""):
             raise FileNotFoundError(f"File {file} not found. Please download it first.")
     else:
         name = "." + str(name)
-    file = os.path.join(folder, "had." + str(order) + name + ".npz")
-    if not os.path.isfile(file):
-        raise FileNotFoundError(f"File {file} not found. Please download it first.")
+        file = os.path.join(folder, "had." + str(order) + name + ".npz")
+        if not os.path.isfile(file):
+            raise FileNotFoundError(f"File {file} not found. Please download it first.")
     arr = np.load(file)["arr_0"]
     converted_had = np.where(arr, 1, -1)
     return converted_had

--- a/spyrit/misc/walsh_hadamard.py
+++ b/spyrit/misc/walsh_hadamard.py
@@ -29,6 +29,9 @@ __deprecated__ = False
 __license__ = "GPLv3"
 __maintainer__ = "developer"
 __status__ = "Development"
+
+import os.path
+
 # __version__ = "0.0.1"
 
 import warnings
@@ -36,9 +39,12 @@ import warnings
 import math
 import torch
 import numpy as np
+import re
 
 import spyrit.core.torch as spytorch
 from sympy.combinatorics.graycode import GrayCode
+
+import spyrit.hadamard_matrix.download_hadamard_matrix
 
 
 # ------------------------------------------------------------------------------
@@ -1394,3 +1400,78 @@ def walsh2_torch(im, H=None):
     raise NotImplementedError(
         "This function is deprecated. Please call spyrit.core.torch.fwht_2d instead."
     )
+
+
+def check_downloaded_hadamard_matrix():
+    """Check if the Hadamard matrix files are downloaded.
+
+    Returns:
+        str: Path to the folder containing the Hadamard matrix files.
+    """
+    spyrit.hadamard_matrix.download_hadamard_matrix.download_from_girder()
+    folder = os.path.join(os.path.dirname(__file__), "..", "hadamard_matrix")
+    return folder
+
+
+def load_matrix(order, name=""):
+    """Load the Walsh-Hadamard matrix from a file
+
+    Args:
+        order (int): Order of the matrix.
+        name (str): Name of the hadamard matrix file of order `order`.
+
+    Returns:
+        np.ndarray: Walsh-Hadamard matrix.
+
+    Example 1:
+        #>>> had = load_matrix(order=28, name="296")
+        #>>> had = load_matrix(order=4)
+        #>>> had = load_matrix(order=508)
+        #>>> had = load_matrix(order=508, name="sage")
+        #>>> had = load_matrix(order=508, name="sage.SDS")
+    """
+    folder = check_downloaded_hadamard_matrix()
+    file = ""
+    if name == "sage":
+        name = ".sage.*"
+        files = glob.glob(os.path.join(folder, "had." + str(order) + name + ".npz"))
+        if len(files) == 0:
+            raise FileNotFoundError(
+                f"File had.{order}{name}.npz not found. Please download it first."
+            )
+        file = files[0]
+        if not os.path.isfile(file):
+            raise FileNotFoundError(f"File {file} not found. Please download it first.")
+    else:
+        name = "." + str(name)
+    file = os.path.join(folder, "had." + str(order) + name + ".npz")
+    if not os.path.isfile(file):
+        raise FileNotFoundError(f"File {file} not found. Please download it first.")
+    arr = np.load(file)["arr_0"]
+    converted_had = np.where(arr, 1, -1)
+    return converted_had
+
+
+def list_available_hadamard_matrix():
+    """List all hadamard matrix available in the hadamard_matrix folder
+
+    Args:
+        order (int): Order of the matrix.
+        name (str): Name of the hadamard matrix file of order `order`.
+
+    Returns:
+        np.ndarray: Walsh-Hadamard matrix.
+
+    Example 1:
+        #>>> print(list_available_hadamard_matrix())
+    """
+
+    # Function to extract numerical parts from the filename
+    def extract_numbers(filename):
+        return list(map(int, re.findall(r"\d+", filename)))
+
+    folder = check_downloaded_hadamard_matrix()
+    files = os.listdir(folder)
+    files = [f for f in files if f.startswith("had.") and f.endswith(".npz")]
+    sorted_filenames = sorted(files, key=extract_numbers)
+    return sorted_filenames


### PR DESCRIPTION
For the moment it's just an automatic downloading and saving to .npz format. We need to do:
 - Get the other hadamard matrix from SageMath software
 - save the .npz matrix into the tomoradio Girder
 - Download the .npz matrix
 - Function to have access to the numpy matrix `mat = spyrit.misc.walsh_hadamard.load_matrix(order=28, name=296)`
 - Thanks to Sloane http://neilsloane.com/hadamard/